### PR TITLE
Enhance simulation CLI with file input and state export

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,22 @@ In interactive mode, you can:
 - Use `/load <filename>` to load the agent's state from a file.
 - Use `/quit` or `/exit` to stop.
 
+#### Custom Input File
+You can provide your own contexts from a file:
+```bash
+python -m simulation --input-file my_contexts.json
+```
+
+Supported file formats:
+- A JSON array (e.g., `["text", {"a": 1}, [1, 2]]`)
+- Newline-delimited values (each line can be JSON or plain text)
+
+#### Save Final State in Demo Mode
+Persist state automatically after demo mode runs:
+```bash
+python -m simulation --save-state agent_state.json
+```
+
 ### 4. Execute the tests
 
 ```bash

--- a/simulation.py
+++ b/simulation.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, List
 
 if __package__:
     from .core import AdaptiveAgent
@@ -15,7 +16,7 @@ else:
     from core import AdaptiveAgent
 
 
-def run_demo(inputs: Iterable[object]) -> None:
+def run_demo(inputs: Iterable[object], *, save_state: str | None = None) -> None:
     agent = AdaptiveAgent()
 
     for index, ctx in enumerate(inputs, start=1):
@@ -29,6 +30,44 @@ def run_demo(inputs: Iterable[object]) -> None:
         print("Meta-state:")
         print(json.dumps(result["meta_state"], indent=2, default=str))
         print("---")
+
+    if save_state:
+        agent.save_state(save_state)
+        print(f"State saved to {save_state}")
+
+
+def parse_context(raw_value: str) -> object:
+    """Parse a single context value from JSON with string fallback."""
+
+    try:
+        return json.loads(raw_value)
+    except json.JSONDecodeError:
+        return raw_value
+
+
+def load_inputs_from_file(filepath: str) -> List[object]:
+    """Load contexts from a JSON file.
+
+    The file can be either:
+    - a JSON array of contexts, or
+    - newline-delimited JSON/text entries.
+    """
+
+    path = Path(filepath)
+    content = path.read_text(encoding="utf-8").strip()
+    if not content:
+        return []
+
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        parsed = [parse_context(line) for line in content.splitlines() if line.strip()]
+        return parsed
+
+    if isinstance(parsed, list):
+        return parsed
+
+    raise ValueError("Input file must contain a JSON array or newline-delimited entries.")
 
 
 def run_interactive() -> None:
@@ -62,11 +101,7 @@ def run_interactive() -> None:
             except Exception as e:
                 print(f"Error loading state: {e}")
         else:
-            # Try to parse input as JSON, else treat as string
-            try:
-                ctx = json.loads(user_input)
-            except json.JSONDecodeError:
-                ctx = user_input
+            ctx = parse_context(user_input)
 
             result = agent.process(ctx)
             print("Adaptation Summary:", result["adaptation_summary"])
@@ -78,19 +113,40 @@ def run_interactive() -> None:
             print("---")
 
 
-def main() -> None:
-    if "--interactive" in sys.argv:
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the adaptive cognitive framework demo.")
+    parser.add_argument("--interactive", action="store_true", help="Run in interactive mode")
+    parser.add_argument(
+        "--input-file",
+        help="Path to a file containing demo contexts (JSON array or newline-delimited entries)",
+    )
+    parser.add_argument(
+        "--save-state",
+        help="Optional path to save final state after demo mode completes",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.interactive:
         run_interactive()
         return
 
-    demo_inputs = [
-        "First context",
-        [1, 2, 3, 4],
-        "Another experience to analyze",
-        {"signal": 42, "status": "stable"},
-        7,
-    ]
-    run_demo(demo_inputs)
+    if args.input_file:
+        demo_inputs = load_inputs_from_file(args.input_file)
+    else:
+        demo_inputs = [
+            "First context",
+            [1, 2, 3, 4],
+            "Another experience to analyze",
+            {"signal": 42, "status": "stable"},
+            7,
+        ]
+    run_demo(demo_inputs, save_state=args.save_state)
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,36 @@
+import json
+import os
+import tempfile
+
+from simulation import load_inputs_from_file, parse_context
+
+
+def test_parse_context_json_and_text():
+    assert parse_context('{"a": 1}') == {"a": 1}
+    assert parse_context("plain text") == "plain text"
+
+
+def test_load_inputs_from_json_array_file():
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".json") as tmp:
+        json.dump(["hello", {"k": "v"}, 3], tmp)
+        tmp_path = tmp.name
+
+    try:
+        result = load_inputs_from_file(tmp_path)
+        assert result == ["hello", {"k": "v"}, 3]
+    finally:
+        os.remove(tmp_path)
+
+
+def test_load_inputs_from_newline_file():
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".txt") as tmp:
+        tmp.write('{"x": 1}\n')
+        tmp.write('plain\n')
+        tmp.write('[1,2]\n')
+        tmp_path = tmp.name
+
+    try:
+        result = load_inputs_from_file(tmp_path)
+        assert result == [{"x": 1}, "plain", [1, 2]]
+    finally:
+        os.remove(tmp_path)


### PR DESCRIPTION
### Motivation
- Provide a clearer CLI for the demo runner so users can supply input files and persist final agent state.
- Reuse parsing logic between interactive and demo modes to make input handling consistent for JSON and plain-text formats.
- Improve documentation and add tests to validate the new input workflows.

### Description
- Refactored `simulation.py` to use `argparse` and added `build_parser`/`main` for `--interactive`, `--input-file`, and `--save-state` flags.
- Added `parse_context` and `load_inputs_from_file` helpers that accept either a JSON array file or newline-delimited JSON/text entries and reused `parse_context` in interactive mode.
- Extended `run_demo` to accept an optional `save_state` parameter and call `agent.save_state` when provided.
- Updated `README.md` with examples for `--input-file` and `--save-state`, and added `tests/test_simulation.py` with coverage for parsing and file-loading behavior.

### Testing
- Ran the full test suite with `pytest -q` and all tests passed (`7 passed`).
- New tests in `tests/test_simulation.py` (JSON parsing fallback, JSON-array file loading, newline-delimited loading) executed successfully under the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eba5a208c8327b4061c5c08a89185)