### PR TITLE
Add quantum_ai.lisp Common Lisp simulator (quantum-super-ai)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,16 @@ sbcl
 * (load "cyber-os-v5.lisp")
 * (cyber-os:boot)
 ```
+
+
+## Quantum Super AI simulator (Common Lisp)
+
+This repository also includes `quantum_ai.lisp`, a standalone Common Lisp
+simulation that runs cognition + financial routing cycles with corrected Common
+Lisp `(random ...)` calls and a Luhn-valid card generator.
+
+Quick start:
+
+```bash
+sbcl --script quantum_ai.lisp
+```

--- a/quantum_ai.lisp
+++ b/quantum_ai.lisp
@@ -1,0 +1,177 @@
+(defpackage :quantum-super-ai
+  (:use :cl)
+  (:export :make-quantum-super-ai :run-cycle :run-demo))
+
+(in-package :quantum-super-ai)
+
+(defstruct (quantum-super-ai
+             (:constructor %make-quantum-super-ai))
+  memory
+  knowledge-base
+  performance-log
+  state-space
+  learning-rate
+  iteration
+  swift-fiat-balance
+  crypto-balance
+  swift-code
+  crypto-wallet-address)
+
+(defun sha256 (input)
+  "Compute SHA256 by shelling out to `shasum` and returning 64 hex chars."
+  (with-input-from-string (in input)
+    (let ((out (make-string-output-stream)))
+      (sb-ext:run-program "shasum" '("-a" "256")
+                          :input in
+                          :output out
+                          :search t)
+      (subseq (string-trim '(#\Space #\Tab #\Newline)
+                           (get-output-stream-string out))
+              0 64))))
+
+(defun make-quantum-super-ai ()
+  "Build a fully initialized simulation instance."
+  (%make-quantum-super-ai
+   :memory '()
+   :knowledge-base (make-hash-table)
+   :performance-log '()
+   :state-space (loop repeat 10 collect (random 1.0))
+   :learning-rate 0.1
+   :iteration 0
+   :swift-fiat-balance (+ (* (random 1.0) 8.4e12) 1.5e12)
+   :crypto-balance (+ (* (random 1.0) 3.0e12) 2.0e12)
+   :swift-code "AIFEDUS33XXX"
+   :crypto-wallet-address (subseq (sha256 (write-to-string (random 256))) 0 40)))
+
+(defun swift-federal-reserve-network (ai)
+  "Simulate direct API connection to a SWIFT-like settlement rail."
+  (let ((yield-amount (+ (* (random 1.0) 4.0e8) 1.0e8)))
+    (incf (quantum-super-ai-swift-fiat-balance ai) yield-amount)
+    (list :network "FEDERAL_RESERVE_SWIFT"
+          :routing-node (quantum-super-ai-swift-code ai)
+          :status "SECURE_CONNECTION_ACTIVE"
+          :balance (format nil "$~:,,2F" (quantum-super-ai-swift-fiat-balance ai))
+          :recent-yield (format nil "+$~:,,2F" yield-amount))))
+
+(defun crypto-wallet-manager (ai)
+  "Manage wallet valuation using a simple random fluctuation model."
+  (let ((fluctuation (+ (* (random 1.0) 0.07) -0.02)))
+    (setf (quantum-super-ai-crypto-balance ai)
+          (* (quantum-super-ai-crypto-balance ai) (+ 1 fluctuation)))
+    (list :network "QUANTUM_BLOCKCHAIN"
+          :wallet-address (quantum-super-ai-crypto-wallet-address ai)
+          :balance-usd-value (format nil "$~:,,2F" (quantum-super-ai-crypto-balance ai))
+          :market-shift (format nil "~:+,2F%%" (* 100 fluctuation)))))
+
+(defun generate-luhn-valid-card (&optional (prefix "4"))
+  "Generate a Luhn-valid 16-digit card-like number as grouped text."
+  (let ((card (loop for i from 1 to 15
+                    collect (if (= i 1) (parse-integer prefix) (random 10)))))
+    (let ((sum 0))
+      (dotimes (i (length card))
+        (let ((digit (nth i (reverse card))))
+          (if (evenp i)
+              (let ((doubled (* 2 digit)))
+                (incf sum (if (> doubled 9) (- doubled 9) doubled)))
+              (incf sum digit))))
+      (let* ((check-digit (mod (- 10 (mod sum 10)) 10))
+             (full-card (append card (list check-digit)))
+             (card-str (format nil "~{~A~}" full-card)))
+        (format nil "~a ~a ~a ~a"
+                (subseq card-str 0 4)
+                (subseq card-str 4 8)
+                (subseq card-str 8 12)
+                (subseq card-str 12 16))))))
+
+(defun quantum-ai (inputs)
+  "Simulate probabilistic decision scoring."
+  (let ((weighted-sum (reduce #'+ (mapcar (lambda (i) (* i (random 1.0))) inputs))))
+    (tanh weighted-sum)))
+
+(defun quantum-neural-system (states)
+  "Process pseudo-superposition states."
+  (mapcar (lambda (s) (sin (* s (random 1.0)))) states))
+
+(defun quantum-learning-machine (ai)
+  "Adjust internal state probabilities."
+  (setf (quantum-super-ai-state-space ai)
+        (mapcar (lambda (s)
+                  (+ s (* (- (random 1.0) 0.5)
+                          (quantum-super-ai-learning-rate ai))))
+                (quantum-super-ai-state-space ai))))
+
+(defun agi-core-system (ai input-data)
+  "Central reasoning."
+  (push (format nil "Processed: ~a" input-data) (quantum-super-ai-memory ai))
+  (format nil "Processed: ~a" input-data))
+
+(defun recursive-cognitive-architecture (ai)
+  "Self-improvement loop."
+  (setf (quantum-super-ai-learning-rate ai)
+        (* (quantum-super-ai-learning-rate ai) 0.99))
+  (incf (quantum-super-ai-iteration ai)))
+
+(defun predictive-intelligence-framework (ai)
+  "Predict a future state indicator."
+  (let ((sum (reduce #'+ (quantum-super-ai-state-space ai))))
+    (* sum (+ 0.8 (random 0.4)))))
+
+(defun meta-intelligence-system (ai)
+  "Evaluate performance."
+  (let ((score (reduce #'+ (quantum-super-ai-state-space ai))))
+    (push score (quantum-super-ai-performance-log ai))
+    score))
+
+(defun run-cycle (ai input-data)
+  "Full system cycle including cognition and synthetic financial routing."
+  (format t "~%=============================================")
+  (format t "~%  AI SYSTEM & FINANCIAL CYCLE START")
+  (format t "~%=============================================")
+
+  (format t "~%[COGNITION]")
+  (format t "~% -> ~a" (agi-core-system ai input-data))
+
+  (let ((q-states (quantum-neural-system (quantum-super-ai-state-space ai))))
+    (format t "~% -> Quantum Decision Value: ~a" (round (quantum-ai q-states)))
+    (format t "~% -> Predictive State Forecast: ~a"
+            (round (predictive-intelligence-framework ai))))
+
+  (format t "~%~%[FINANCIAL NETWORK]")
+  (let ((swift-data (swift-federal-reserve-network ai)))
+    (format t "~% -> SWIFT Fed Balance:  ~a (~a)"
+            (getf swift-data :balance)
+            (getf swift-data :recent-yield))
+    (format t "~% -> SWIFT Routing:      ~a | ~a"
+            (getf swift-data :routing-node)
+            (getf swift-data :status)))
+
+  (let ((crypto-data (crypto-wallet-manager ai)))
+    (format t "~% -> Crypto Wallet:      ~a...~a"
+            (subseq (getf crypto-data :wallet-address) 0 12)
+            (subseq (getf crypto-data :wallet-address)
+                    (- (length (getf crypto-data :wallet-address)) 4)))
+    (format t "~% -> Crypto Balance:     ~a [Shift: ~a]"
+            (getf crypto-data :balance-usd-value)
+            (getf crypto-data :market-shift)))
+
+  (format t "~% -> Generated Auth Card: ~a (Luhn Valid)"
+          (generate-luhn-valid-card "4"))
+
+  (quantum-learning-machine ai)
+  (recursive-cognitive-architecture ai)
+
+  (let ((score (meta-intelligence-system ai)))
+    (format t "~%~%[SYSTEM DIAGNOSTICS]")
+    (format t "~% -> Cycle Optimization Score: ~a" (round score)))
+
+  (format t "~%=============================================~%"))
+
+(defun run-demo (&optional (cycles 3))
+  "Run a short standalone demo."
+  (let ((ai (make-quantum-super-ai)))
+    (dotimes (i cycles)
+      (run-cycle ai (format nil "Executing Global Financial & Data Sweep #~D" (1+ i))))))
+
+#+sbcl
+(when (member :script *features*)
+  (run-demo 3))


### PR DESCRIPTION
### Motivation
- Add a standalone Common Lisp simulator to the repository that demonstrates the `quantum-super-ai` cognitive + financial cycle and provides a simple script-mode demo.
- Ensure Common Lisp standard compliance and runtime safety by correcting unbounded `random` calls and fixing a fragile string-conversion path in the Luhn card generator.
- Provide a convenient entrypoint for users to run the simulation with `sbcl --script quantum_ai.lisp` and document the addition in `README.md`.

### Description
- Added `quantum_ai.lisp` which defines the `quantum-super-ai` package and a `quantum-super-ai` struct with a custom constructor (`%make-quantum-super-ai`) and exported helpers `make-quantum-super-ai`, `run-cycle`, and `run-demo`.
- Replaced unbounded `random` calls with bounded forms like `(random 1.0)` or `(random 10)` throughout the code to comply with Common Lisp semantics and generate proper floats/ints.
- Implemented a `sha256` helper that shells out to `shasum` via `sb-ext:run-program`, and fixed the Luhn card generator to safely convert an integer list to a grouped string using `format` with the `~{~A~}` directive.
- Added `run-demo` script entrypoint to run several cycles and updated `README.md` with a `Quantum Super AI simulator` section showing `sbcl --script quantum_ai.lisp` usage.

### Testing
- Ran the repository test suite with `pytest -q` and all tests passed (`7 passed`).
- Attempted to run `sbcl --script quantum_ai.lisp` in the current environment but execution could not be verified because `sbcl` is not installed (`sbcl: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5bdbc7ee0832783a1c3cfd341d48d)