### PR TITLE
Add batch/state helper APIs and simulation summary utility

### DIFF
--- a/core.py
+++ b/core.py
@@ -24,6 +24,20 @@ class AdaptiveAgent:
             "meta_state": self.state.report()
         }
 
+    def process_batch(self, contexts):
+        """Process a sequence of contexts and return all results."""
+        return [self.process(ctx) for ctx in contexts]
+
+    def reset_state(self) -> None:
+        """Reset the agent to a fresh introspective state."""
+        self.state = IntrospectiveState()
+        self.adaptive_loop = AdaptiveLoop(self.state)
+        self.reflective_processor = ReflectiveProcessor(self.state)
+
+    def get_state_snapshot(self) -> dict:
+        """Return a serializable snapshot of the current internal state."""
+        return self.state.to_dict()
+
     def save_state(self, filepath: str) -> None:
         """Save the agent's internal state to a file."""
         import json

--- a/simulation.py
+++ b/simulation.py
@@ -36,6 +36,24 @@ def run_demo(inputs: Iterable[object], *, save_state: str | None = None) -> None
         print(f"State saved to {save_state}")
 
 
+def summarize_results(results: List[dict]) -> dict:
+    """Build a compact summary from a list of process results."""
+
+    if not results:
+        return {
+            "total_steps": 0,
+            "last_adaptation_summary": None,
+            "final_history_length": 0,
+        }
+
+    last = results[-1]
+    return {
+        "total_steps": len(results),
+        "last_adaptation_summary": last.get("adaptation_summary"),
+        "final_history_length": last.get("meta_state", {}).get("history_length", 0),
+    }
+
+
 def parse_context(raw_value: str) -> object:
     """Parse a single context value from JSON with string fallback."""
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -73,3 +73,19 @@ def test_agent_handles_various_inputs():
         assert result["adaptation_summary"].startswith("Processed")
         assert "valence" in result["reflection"].lower()
         assert result["meta_state"]["history_length"] >= 1
+
+
+def test_agent_batch_snapshot_and_reset():
+    agent = AdaptiveAgent()
+    results = agent.process_batch(["one", {"x": 1}, [1, 2]])
+
+    assert len(results) == 3
+    assert results[-1]["meta_state"]["history_length"] == 3
+
+    snapshot = agent.get_state_snapshot()
+    assert "history" in snapshot
+    assert len(snapshot["history"]) == 3
+
+    agent.reset_state()
+    post_reset = agent.state.report()
+    assert post_reset["history_length"] == 0

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -2,7 +2,7 @@ import json
 import os
 import tempfile
 
-from simulation import load_inputs_from_file, parse_context
+from simulation import load_inputs_from_file, parse_context, summarize_results
 
 
 def test_parse_context_json_and_text():
@@ -34,3 +34,28 @@ def test_load_inputs_from_newline_file():
         assert result == [{"x": 1}, "plain", [1, 2]]
     finally:
         os.remove(tmp_path)
+
+
+def test_summarize_results_handles_empty_and_populated_inputs():
+    empty_summary = summarize_results([])
+    assert empty_summary["total_steps"] == 0
+    assert empty_summary["last_adaptation_summary"] is None
+
+    populated_summary = summarize_results(
+        [
+            {
+                "adaptation_summary": "Processed text",
+                "meta_state": {"history_length": 1},
+            },
+            {
+                "adaptation_summary": "Processed list",
+                "meta_state": {"history_length": 2},
+            },
+        ]
+    )
+
+    assert populated_summary == {
+        "total_steps": 2,
+        "last_adaptation_summary": "Processed list",
+        "final_history_length": 2,
+    }


### PR DESCRIPTION
### Motivation
- Provide higher-level helper APIs to make the agent easier to use in batch workflows and testing. 
- Expose a serializable state snapshot and a way to reset the agent so external tooling can manage agent lifecycle. 
- Offer a compact summarizer for simulation results to simplify reporting and downstream analysis. 

### Description
- Added `AdaptiveAgent.process_batch(contexts)`, `AdaptiveAgent.reset_state()`, and `AdaptiveAgent.get_state_snapshot()` to `core.py` to support batch processing, state reinitialization, and serializable snapshots. 
- Added `summarize_results(results)` to `simulation.py` which returns `total_steps`, `last_adaptation_summary`, and `final_history_length` for a run. 
- Expanded tests to cover the new APIs by adding `test_agent_batch_snapshot_and_reset` in `tests/test_agent.py` and `test_summarize_results_handles_empty_and_populated_inputs` in `tests/test_simulation.py`. 

### Testing
- Ran `pytest -q` which executed the test suite and reported `9 passed`. 
- New tests `tests/test_agent.py::test_agent_batch_snapshot_and_reset` and `tests/test_simulation.py::test_summarize_results_handles_empty_and_populated_inputs` passed successfully. 
- Existing tests continued to pass with the additions, confirming backwards compatibility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f840aeab108327a3f159b561941da8)