### PR TITLE
Enhance adaptive diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,24 @@ Persist state automatically after demo mode runs:
 python -m simulation --save-state agent_state.json
 ```
 
+
+### New adaptive diagnostics
+
+Every processing cycle now returns an enriched adaptation payload in addition to
+the original summary fields. The payload includes:
+
+- `confidence`: a best-effort score for how strongly the agent understood the
+  input shape.
+- `recommendations`: practical next actions derived from the context type.
+- Type-specific diagnostics such as lexical diversity for text, entropy and
+  distribution metrics for sequences, schema hints for mappings, and normalized
+  scale comparisons for numbers.
+- Rolling introspection metadata including novelty scores, dominant context type,
+  and an observation log.
+
+This keeps the project useful as an adaptive simulation without asserting real
+AI sentience or hidden autonomous capabilities.
+
 ### 4. Execute the tests
 
 ```bash

--- a/adaptation.py
+++ b/adaptation.py
@@ -1,9 +1,15 @@
-"""Adaptive reasoning loop for the agent."""
+"""Adaptive reasoning loop for the agent.
+
+The module intentionally models *adaptive behavior* rather than claiming real
+sentience.  It extracts practical signals from each input context, estimates a
+confidence score, and returns next-step recommendations that callers can act on.
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Dict, Iterable, Optional
+from dataclasses import dataclass, field
+from math import log2
+from typing import Any, Dict, Iterable, List, Optional
 
 import numpy as np
 
@@ -14,15 +20,49 @@ class AdaptationResult:
 
     summary: str
     details: Dict[str, Any]
+    confidence: float = 0.0
+    recommendations: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-friendly representation of the adaptation result."""
+
+        return {
+            "summary": self.summary,
+            "details": self.details,
+            "confidence": round(self.confidence, 4),
+            "recommendations": list(self.recommendations),
+        }
 
 
 class AdaptiveLoop:
     """Compute a best-effort adaptation based on the latest context."""
 
+    POSITIVE_MARKERS = {
+        "better",
+        "clear",
+        "excellent",
+        "great",
+        "improve",
+        "stable",
+        "success",
+        "useful",
+    }
+    NEGATIVE_MARKERS = {
+        "bad",
+        "broken",
+        "error",
+        "fail",
+        "risk",
+        "unstable",
+        "worse",
+    }
+
     def __init__(self, state) -> None:
         self.state = state
 
     def run(self) -> Optional[AdaptationResult]:
+        """Adapt to the latest observed context and update introspective state."""
+
         if not self.state.history:
             return None
 
@@ -33,60 +73,158 @@ class AdaptiveLoop:
         return result
 
     def _adapt_context(self, context: Any) -> AdaptationResult:
+        descriptor = self.state._describe_context(context)
+        novelty = self.state.meta_context.get("last_novelty_score", self.state.novelty_score(context))
+
         if isinstance(context, str):
-            reversed_text = context[::-1]
-            tokens = context.split()
-            unique_tokens = len(set(tokens)) if tokens else 0
-            summary = "Processed textual context"
-            details = {
-                "transformation": "reverse",
-                "token_count": len(tokens),
-                "unique_tokens": unique_tokens,
-                "reversed": reversed_text,
-                "valence_delta": 0.02 if unique_tokens else 0.01,
-            }
-            return AdaptationResult(summary=summary, details=details)
+            return self._adapt_text(context, novelty)
 
         if isinstance(context, (list, tuple, set, np.ndarray)):
-            sequence = list(context)
-            reversed_sequence = list(reversed(sequence))
-            mean_value = float(np.mean(sequence)) if self._is_numeric_sequence(sequence) else None
-            summary = "Processed sequence context"
-            details = {
-                "transformation": "reverse",
-                "length": len(sequence),
-                "mean": mean_value,
-                "reversed": reversed_sequence,
-                "valence_delta": 0.015,
-            }
-            return AdaptationResult(summary=summary, details=details)
+            return self._adapt_sequence(context, novelty)
 
         if isinstance(context, dict):
-            summary = "Processed mapping context"
-            details = {
-                "keys": list(context.keys()),
-                "values": list(context.values()),
-                "valence_delta": 0.012,
-            }
-            return AdaptationResult(summary=summary, details=details)
+            return self._adapt_mapping(context, novelty)
 
-        if isinstance(context, (int, float)):
-            summary = "Processed numeric context"
-            details = {
-                "value": context,
-                "normalized": self._normalize_numeric(context),
-                "valence_delta": 0.01,
-            }
-            return AdaptationResult(summary=summary, details=details)
+        if isinstance(context, (int, float)) and not isinstance(context, bool):
+            return self._adapt_numeric(context, novelty)
 
         summary = "Processed miscellaneous context"
-        details = {"representation": repr(context), "valence_delta": 0.005}
-        return AdaptationResult(summary=summary, details=details)
+        details = {
+            "descriptor": descriptor,
+            "representation": repr(context),
+            "novelty_score": novelty,
+            "valence_delta": 0.004 + (0.002 * novelty),
+        }
+        return AdaptationResult(
+            summary=summary,
+            details=details,
+            confidence=0.35,
+            recommendations=["Provide a JSON-serializable structure for richer analysis."],
+        )
+
+    def _adapt_text(self, context: str, novelty: float) -> AdaptationResult:
+        tokens = context.split()
+        normalized_tokens = [token.strip(".,!?;:'\"").lower() for token in tokens]
+        normalized_tokens = [token for token in normalized_tokens if token]
+        unique_tokens = len(set(normalized_tokens)) if normalized_tokens else 0
+        lexical_diversity = unique_tokens / len(normalized_tokens) if normalized_tokens else 0.0
+        positive_hits = sum(token in self.POSITIVE_MARKERS for token in normalized_tokens)
+        negative_hits = sum(token in self.NEGATIVE_MARKERS for token in normalized_tokens)
+        sentiment_hint = positive_hits - negative_hits
+
+        details = {
+            "descriptor": "text",
+            "transformation": "tokenize/reverse/sentiment-hint",
+            "token_count": len(tokens),
+            "unique_tokens": unique_tokens,
+            "lexical_diversity": round(lexical_diversity, 4),
+            "sentiment_hint": sentiment_hint,
+            "reversed": context[::-1],
+            "novelty_score": novelty,
+            "valence_delta": 0.012 + (0.015 * lexical_diversity) + (0.006 * sentiment_hint),
+        }
+        recommendations = [
+            "Keep text concise and specific for higher-confidence adaptation.",
+            "Add structured fields when you need machine-readable follow-up actions.",
+        ]
+        confidence = min(0.95, 0.45 + (0.3 * lexical_diversity) + (0.1 * novelty))
+        return AdaptationResult(
+            summary="Processed textual context with lexical and sentiment signals",
+            details=details,
+            confidence=confidence,
+            recommendations=recommendations,
+        )
+
+    def _adapt_sequence(self, context: Iterable[Any], novelty: float) -> AdaptationResult:
+        sequence = list(context)
+        numeric = self._is_numeric_sequence(sequence)
+        mean_value = float(np.mean(sequence)) if sequence and numeric else None
+        std_value = float(np.std(sequence)) if sequence and numeric else None
+        entropy = self._sequence_entropy(sequence)
+
+        details = {
+            "descriptor": "sequence",
+            "transformation": "profile/reverse/statistics",
+            "length": len(sequence),
+            "mean": mean_value,
+            "standard_deviation": std_value,
+            "entropy": round(entropy, 4),
+            "reversed": list(reversed(sequence)),
+            "novelty_score": novelty,
+            "valence_delta": 0.01 + (0.005 * min(entropy, 1.0)),
+        }
+        recommendations = ["Normalize sequence lengths before comparing batches."]
+        if numeric:
+            recommendations.append("Track mean and standard deviation drift over time.")
+        confidence = 0.7 if numeric else 0.55
+        return AdaptationResult(
+            summary="Processed sequence context with distribution metrics",
+            details=details,
+            confidence=confidence + (0.05 * novelty),
+            recommendations=recommendations,
+        )
+
+    def _adapt_mapping(self, context: Dict[Any, Any], novelty: float) -> AdaptationResult:
+        keys = list(context.keys())
+        value_types = {str(key): type(value).__name__ for key, value in context.items()}
+        missing_like = [key for key, value in context.items() if value in (None, "")]
+
+        details = {
+            "descriptor": "mapping",
+            "transformation": "schema-profile",
+            "keys": keys,
+            "values": list(context.values()),
+            "value_types": value_types,
+            "missing_like_keys": missing_like,
+            "field_count": len(keys),
+            "novelty_score": novelty,
+            "valence_delta": 0.012 + (0.002 * len(keys)) - (0.003 * len(missing_like)),
+        }
+        recommendations = ["Preserve stable key names so adaptation history stays comparable."]
+        if missing_like:
+            recommendations.append("Fill missing-like fields to improve downstream confidence.")
+        confidence = min(0.92, 0.55 + (0.04 * len(keys)) + (0.04 * novelty))
+        return AdaptationResult(
+            summary="Processed mapping context with schema diagnostics",
+            details=details,
+            confidence=confidence,
+            recommendations=recommendations,
+        )
+
+    def _adapt_numeric(self, context: float, novelty: float) -> AdaptationResult:
+        normalized = self._normalize_numeric(context)
+        magnitude = abs(float(context))
+        details = {
+            "descriptor": "numeric",
+            "value": context,
+            "normalized": normalized,
+            "magnitude": magnitude,
+            "sign": "positive" if context > 0 else "negative" if context < 0 else "zero",
+            "novelty_score": novelty,
+            "valence_delta": 0.008 + (0.004 * novelty),
+        }
+        return AdaptationResult(
+            summary="Processed numeric context with normalization metrics",
+            details=details,
+            confidence=0.82,
+            recommendations=["Compare normalized values when inputs span different scales."],
+        )
 
     @staticmethod
     def _is_numeric_sequence(sequence: Iterable[Any]) -> bool:
-        return all(isinstance(item, (int, float)) for item in sequence)
+        return all(isinstance(item, (int, float)) and not isinstance(item, bool) for item in sequence)
 
     @staticmethod
     def _normalize_numeric(value: float) -> float:
-        return 1 / (1 + np.exp(-value))
+        return float(1 / (1 + np.exp(-value)))
+
+    @staticmethod
+    def _sequence_entropy(sequence: List[Any]) -> float:
+        if not sequence:
+            return 0.0
+        counts: Dict[str, int] = {}
+        for item in sequence:
+            key = repr(item)
+            counts[key] = counts.get(key, 0) + 1
+        total = len(sequence)
+        return -sum((count / total) * log2(count / total) for count in counts.values())

--- a/core.py
+++ b/core.py
@@ -8,20 +8,27 @@ else:
     from reflection import ReflectiveProcessor
 
 class AdaptiveAgent:
+    """High-level orchestrator for observation, adaptation, and reflection."""
+
     def __init__(self):
         self.state = IntrospectiveState()
         self.adaptive_loop = AdaptiveLoop(self.state)
         self.reflective_processor = ReflectiveProcessor(self.state)
 
     def process(self, input_context):
+        """Process one context and return a structured cognitive cycle report."""
+
         self.state.observe(input_context)
         adaptation = self.adaptive_loop.run()
         reflection = self.reflective_processor.reflect(adaptation)
+        adaptation_payload = adaptation.to_dict() if adaptation else None
         return {
             "processed_context": adaptation.details if adaptation else None,
             "adaptation_summary": adaptation.summary if adaptation else None,
+            "adaptation": adaptation_payload,
             "reflection": reflection,
-            "meta_state": self.state.report()
+            "meta_state": self.state.report(),
+            "recommendations": adaptation.recommendations if adaptation else [],
         }
 
     def process_batch(self, contexts):

--- a/introspection.py
+++ b/introspection.py
@@ -3,23 +3,23 @@
 from __future__ import annotations
 
 from collections import deque
+from copy import deepcopy
 from statistics import mean
 from typing import Any, Deque, Dict, List
 
 
 class IntrospectiveState:
-    """Tracks the internal history and meta-context for the agent.
-
-    The original project stored only the latest context and a simple valence
-    value.  To make the agent more informative we now maintain:
-
-    - A rolling memory of recent contexts for lightweight analysis.
-    - Type statistics for quick introspective reporting.
-    - A history of valence updates so we can provide trend information.
-    - A registry of the most recent adaptations for later reflection.
-    """
+    """Tracks history, metrics, and rolling diagnostics for the agent."""
 
     HISTORY_WINDOW = 5
+    DEFAULT_CONTEXT_STATS = {
+        "text": 0,
+        "sequence": 0,
+        "mapping": 0,
+        "numeric": 0,
+        "boolean": 0,
+        "other": 0,
+    }
 
     def __init__(self) -> None:
         self.history: List[Any] = []
@@ -27,28 +27,35 @@ class IntrospectiveState:
         self.meta_context: Dict[str, Any] = {}
         self.emotional_valence: float = 0.0
         self.valence_trace: Deque[float] = deque(maxlen=self.HISTORY_WINDOW)
-        self.context_stats: Dict[str, int] = {
-            "text": 0,
-            "sequence": 0,
-            "mapping": 0,
-            "numeric": 0,
-            "other": 0,
-        }
+        self.context_stats: Dict[str, int] = dict(self.DEFAULT_CONTEXT_STATS)
         self.adaptation_log: Deque[str] = deque(maxlen=self.HISTORY_WINDOW)
+        self.observation_log: Deque[Dict[str, Any]] = deque(maxlen=self.HISTORY_WINDOW)
 
     def observe(self, context: Any) -> None:
         """Store the incoming context and update summary information."""
 
+        descriptor = self._describe_context(context)
+        size = self._estimate_size(context)
+        novelty = self.novelty_score(context)
+
         self.history.append(context)
         self.recent_contexts.append(context)
-        descriptor = self._describe_context(context)
-        self.context_stats[descriptor] += 1
+        self.context_stats[descriptor] = self.context_stats.get(descriptor, 0) + 1
+        observation = {
+            "index": len(self.history),
+            "descriptor": descriptor,
+            "size": size,
+            "novelty_score": novelty,
+        }
+        self.observation_log.append(observation)
 
         self.meta_context.update(
             {
                 "last": context,
                 "last_descriptor": descriptor,
-                "last_size": self._estimate_size(context),
+                "last_size": size,
+                "last_novelty_score": novelty,
+                "last_observation": observation,
             }
         )
 
@@ -72,10 +79,13 @@ class IntrospectiveState:
             "recent_context": self.meta_context.get("last"),
             "recent_context_descriptor": self.meta_context.get("last_descriptor"),
             "recent_context_size": self.meta_context.get("last_size"),
+            "recent_context_novelty": round(self.meta_context.get("last_novelty_score", 0.0), 4),
             "emotional_valence": round(self.emotional_valence, 4),
             "valence_trend": round(rolling_average, 4),
             "context_stats": dict(self.context_stats),
+            "dominant_context_type": self.dominant_context_type(),
             "recent_adaptations": list(self.adaptation_log),
+            "observation_log": list(self.observation_log),
         }
 
     def summarize_recent_contexts(self) -> List[str]:
@@ -88,20 +98,43 @@ class IntrospectiveState:
             summaries.append(f"{descriptor} (size={size})")
         return summaries
 
+    def novelty_score(self, context: Any) -> float:
+        """Estimate whether the context differs from the current rolling window."""
+
+        if not self.recent_contexts:
+            return 1.0
+        descriptor = self._describe_context(context)
+        descriptor_matches = sum(
+            1 for recent in self.recent_contexts if self._describe_context(recent) == descriptor
+        )
+        repetition_penalty = descriptor_matches / len(self.recent_contexts)
+        return round(max(0.0, 1.0 - repetition_penalty), 4)
+
+    def dominant_context_type(self) -> str | None:
+        """Return the most frequently observed context descriptor."""
+
+        non_zero = {key: value for key, value in self.context_stats.items() if value > 0}
+        if not non_zero:
+            return None
+        return max(non_zero, key=non_zero.get)
+
     def to_dict(self) -> Dict[str, Any]:
         """Serialize the current state to a dictionary."""
+
         return {
-            "history": self.history,
+            "history": deepcopy(self.history),
             "recent_contexts": list(self.recent_contexts),
-            "meta_context": self.meta_context,
+            "meta_context": deepcopy(self.meta_context),
             "emotional_valence": self.emotional_valence,
             "valence_trace": list(self.valence_trace),
-            "context_stats": self.context_stats,
+            "context_stats": dict(self.context_stats),
             "adaptation_log": list(self.adaptation_log),
+            "observation_log": list(self.observation_log),
         }
 
     def load_from_dict(self, data: Dict[str, Any]) -> None:
         """Restore the state from a dictionary."""
+
         self.history = data.get("history", [])
         self.recent_contexts = deque(
             data.get("recent_contexts", []), maxlen=self.HISTORY_WINDOW
@@ -111,17 +144,20 @@ class IntrospectiveState:
         self.valence_trace = deque(
             data.get("valence_trace", []), maxlen=self.HISTORY_WINDOW
         )
-        self.context_stats = data.get(
-            "context_stats",
-            {"text": 0, "sequence": 0, "mapping": 0, "numeric": 0, "other": 0},
-        )
+        self.context_stats = dict(self.DEFAULT_CONTEXT_STATS)
+        self.context_stats.update(data.get("context_stats", {}))
         self.adaptation_log = deque(
             data.get("adaptation_log", []), maxlen=self.HISTORY_WINDOW
+        )
+        self.observation_log = deque(
+            data.get("observation_log", []), maxlen=self.HISTORY_WINDOW
         )
 
     def _describe_context(self, context: Any) -> str:
         if isinstance(context, str):
             return "text"
+        if isinstance(context, bool):
+            return "boolean"
         if isinstance(context, (list, tuple, set)):
             return "sequence"
         if isinstance(context, dict):

--- a/reflection.py
+++ b/reflection.py
@@ -11,6 +11,8 @@ else:
 
 
 class ReflectiveProcessor:
+    """Generate compact narrative summaries from state and adaptation output."""
+
     def __init__(self, state):
         self.state = state
 
@@ -18,14 +20,21 @@ class ReflectiveProcessor:
         if not self.state.history:
             return "No context to reflect on."
 
+        report = self.state.report()
         summaries = ", ".join(self.state.summarize_recent_contexts())
         valence = self.state.emotional_valence
-        trend = self.state.report()["valence_trend"]
+        trend = report["valence_trend"]
+        dominant = report["dominant_context_type"] or "n/a"
+        novelty = report["recent_context_novelty"]
         adaptation_summary = adaptation.summary if adaptation else "No new adaptation"
+        confidence = adaptation.confidence if adaptation else 0.0
         return (
             "Reflection: "
             f"observed {len(self.state.history)} contexts; "
             f"recent types: {summaries or 'n/a'}; "
+            f"dominant type: {dominant}; "
             f"latest adaptation: {adaptation_summary}; "
+            f"confidence={confidence:.2f}; "
+            f"novelty={novelty:.2f}; "
             f"valence={valence:.2f}, trend={trend:.2f}"
         )

--- a/simulation.py
+++ b/simulation.py
@@ -24,6 +24,9 @@ def run_demo(inputs: Iterable[object], *, save_state: str | None = None) -> None
         print(f"Step {index}")
         print("Input:", ctx)
         print("Adaptation Summary:", result["adaptation_summary"])
+        print("Adaptation Confidence:", result.get("adaptation", {}).get("confidence"))
+        print("Recommendations:")
+        print(json.dumps(result.get("recommendations", []), indent=2, default=str))
         print("Processed Context:")
         print(json.dumps(result["processed_context"], indent=2, default=str))
         print("Reflection:", result["reflection"])
@@ -44,13 +47,24 @@ def summarize_results(results: List[dict]) -> dict:
             "total_steps": 0,
             "last_adaptation_summary": None,
             "final_history_length": 0,
+            "average_confidence": 0.0,
         }
 
     last = results[-1]
+    confidence_values = [
+        item.get("adaptation", {}).get("confidence", 0.0)
+        for item in results
+        if item.get("adaptation")
+    ]
+    average_confidence = (
+        sum(confidence_values) / len(confidence_values) if confidence_values else 0.0
+    )
+
     return {
         "total_steps": len(results),
         "last_adaptation_summary": last.get("adaptation_summary"),
         "final_history_length": last.get("meta_state", {}).get("history_length", 0),
+        "average_confidence": round(average_confidence, 4),
     }
 
 
@@ -123,6 +137,9 @@ def run_interactive() -> None:
 
             result = agent.process(ctx)
             print("Adaptation Summary:", result["adaptation_summary"])
+            print("Adaptation Confidence:", result.get("adaptation", {}).get("confidence"))
+            print("Recommendations:")
+            print(json.dumps(result.get("recommendations", []), indent=2, default=str))
             print("Processed Context:")
             print(json.dumps(result["processed_context"], indent=2, default=str))
             print("Reflection:", result["reflection"])

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -48,13 +48,18 @@ def test_agent_process_structure():
     assert set(result.keys()) == {
         "processed_context",
         "adaptation_summary",
+        "adaptation",
         "reflection",
         "meta_state",
+        "recommendations",
     }
 
     assert isinstance(result["processed_context"], dict)
     assert result["adaptation_summary"]
+    assert result["adaptation"]["confidence"] > 0
+    assert result["recommendations"]
     assert "valence" in result["reflection"].lower()
+    assert "confidence" in result["reflection"].lower()
 
     meta_state = result["meta_state"]
     assert meta_state["history_length"] == 1
@@ -89,3 +94,37 @@ def test_agent_batch_snapshot_and_reset():
     agent.reset_state()
     post_reset = agent.state.report()
     assert post_reset["history_length"] == 0
+
+
+def test_enriched_adaptation_metrics_for_core_types():
+    agent = AdaptiveAgent()
+
+    text_result = agent.process("make this better and stable")
+    assert text_result["processed_context"]["lexical_diversity"] > 0
+    assert text_result["processed_context"]["sentiment_hint"] >= 2
+
+    sequence_result = agent.process([1, 1, 2, 3])
+    assert sequence_result["processed_context"]["mean"] == 1.75
+    assert "entropy" in sequence_result["processed_context"]
+
+    mapping_result = agent.process({"signal": 42, "status": ""})
+    assert mapping_result["processed_context"]["value_types"] == {
+        "signal": "int",
+        "status": "str",
+    }
+    assert mapping_result["processed_context"]["missing_like_keys"] == ["status"]
+
+    numeric_result = agent.process(-2)
+    assert numeric_result["processed_context"]["sign"] == "negative"
+    assert 0 < numeric_result["processed_context"]["normalized"] < 1
+
+
+def test_meta_state_tracks_novelty_and_dominant_type():
+    agent = AdaptiveAgent()
+    agent.process("first")
+    result = agent.process("second")
+
+    meta_state = result["meta_state"]
+    assert meta_state["dominant_context_type"] == "text"
+    assert meta_state["recent_context_novelty"] == 0.0
+    assert meta_state["observation_log"][-1]["descriptor"] == "text"

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -40,16 +40,19 @@ def test_summarize_results_handles_empty_and_populated_inputs():
     empty_summary = summarize_results([])
     assert empty_summary["total_steps"] == 0
     assert empty_summary["last_adaptation_summary"] is None
+    assert empty_summary["average_confidence"] == 0.0
 
     populated_summary = summarize_results(
         [
             {
                 "adaptation_summary": "Processed text",
                 "meta_state": {"history_length": 1},
+                "adaptation": {"confidence": 0.4},
             },
             {
                 "adaptation_summary": "Processed list",
                 "meta_state": {"history_length": 2},
+                "adaptation": {"confidence": 0.8},
             },
         ]
     )
@@ -58,4 +61,5 @@ def test_summarize_results_handles_empty_and_populated_inputs():
         "total_steps": 2,
         "last_adaptation_summary": "Processed list",
         "final_history_length": 2,
+        "average_confidence": 0.6,
     }


### PR DESCRIPTION
### Motivation

- Provide richer, structured adaptation outputs so callers can act on confidence, recommendations, and type-specific diagnostics rather than just a textual summary.
- Improve internal state tracking with novelty, dominant context type and an observation log to make introspection more useful for downstream analytics and persistence.
- Surface diagnostic signals in the demo/CLI and validate behavior with tests to ensure the extended contract is stable and serializable.

### Description

- Add `confidence`, `recommendations`, and `to_dict()` to `AdaptationResult`, split `_adapt_context` into type-specific handlers, and compute lexical/diversity/sentiment hints for text, entropy/statistics for sequences, schema diagnostics for mappings, and normalized metrics for numerics in `adaptation.py`.
- Extend `AdaptiveAgent.process` to include an `adaptation` payload and top-level `recommendations` in the return value so callers receive the enriched result alongside the original fields in `core.py`.
- Expand `IntrospectiveState` in `introspection.py` with novelty scoring, `observation_log`, boolean context classification, dominant-context detection, safer snapshot serialization via `deepcopy`, and robust load/save behavior.
- Enhance `ReflectiveProcessor` in `reflection.py` to include adaptation `confidence`, novelty, and dominant context type in narrative summaries.
- Surface `adaptation` confidence and `recommendations` in `simulation.py` output and add average confidence to `summarize_results`.
- Update documentation in `README.md` to describe the new diagnostics and add/adjust tests in `tests/` to cover the enriched response shape, type-specific metrics, novelty/dominant-type tracking, and summarized confidence.

### Testing

- Ran the test suite with `pytest -q`, all tests passed (`11 passed`).
- Verified bytecode compilation with `python -m compileall .`, which completed without errors.
- Exercised the demo runner with `python -m simulation | head -45` to confirm the enriched output (confidence, recommendations, and meta-state) displays as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faea9ac7e48327823b16102065e909)