### PR TITLE
Enhance adaptive agent analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ The original version offered a minimal skeleton. This revision expands the
 simulation to provide richer metrics, structured adaptation results, and more
 practical documentation. The framework now:
 
-- Tracks detailed meta-context information (recent context types, sizes, and
-  adaptation history).
-- Produces structured adaptation results with type-specific insights.
-- Generates reflective summaries that surface recent behaviour and emotional
-  valence trends.
+- Tracks detailed meta-context information (recent context types, sizes,
+  transition counts, novelty score, cognitive load, and adaptation history).
+- Produces structured adaptation results with type-specific insights, selected
+  strategy names, confidence scores, and signal tags for downstream tooling.
+- Generates reflective summaries that surface recent behaviour, emotional
+  valence trends, strategy confidence, novelty, and a recommended next focus.
 - Includes a CLI-friendly simulation runner with an **interactive mode** and
   **persistence capabilities** (save/load state).
 - Includes automated tests to validate the basic contract of the agent.
@@ -90,10 +91,35 @@ python -m simulation --save-state agent_state.json
 pytest
 ```
 
+
+## Structured result example
+
+`AdaptiveAgent.process(...)` now returns both backward-compatible summary fields
+and a richer `adaptation` object:
+
+```python
+{
+    "adaptation_summary": "Processed textual context with lexical profiling",
+    "adaptation": {
+        "strategy": "text-lexical-profiler",
+        "confidence": 0.85,
+        "signals": ["textual_signal", "high_lexical_diversity"],
+        "details": {"token_count": 7, "lexical_diversity": 1.0},
+    },
+    "meta_state": {
+        "dominant_context_type": "text",
+        "novelty_score": 0.0,
+        "cognitive_load": 0.48,
+    },
+}
+```
+
 ## Extending the framework
 
-- Add new adaptation strategies by extending `AdaptiveLoop._adapt_context` and
-  logging human-readable summaries via `IntrospectiveState.record_adaptation`.
+- Add new adaptation strategies by extending `AdaptiveLoop._adapt_context` or one
+  of its type-specific helpers (`_adapt_text`, `_adapt_sequence`,
+  `_adapt_mapping`, `_adapt_numeric`) and logging human-readable summaries via
+  `IntrospectiveState.record_adaptation`.
 - Experiment with alternative reflection styles by modifying
   `ReflectiveProcessor.reflect`.
 - Integrate external data sources by feeding structured inputs to

--- a/adaptation.py
+++ b/adaptation.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Dict, Iterable, Optional
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional
 
 import numpy as np
 
@@ -14,6 +17,20 @@ class AdaptationResult:
 
     summary: str
     details: Dict[str, Any]
+    strategy: str = "general"
+    confidence: float = 0.5
+    signals: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serializable representation of the adaptation result."""
+
+        return {
+            "summary": self.summary,
+            "strategy": self.strategy,
+            "confidence": round(self.confidence, 4),
+            "signals": list(self.signals),
+            "details": self.details,
+        }
 
 
 class AdaptiveLoop:
@@ -30,63 +47,195 @@ class AdaptiveLoop:
         result = self._adapt_context(last)
         self.state.update_valence(result.details.get("valence_delta", 0.0))
         self.state.record_adaptation(result.summary)
+        self.state.record_signal_bundle(result.signals)
         return result
 
     def _adapt_context(self, context: Any) -> AdaptationResult:
         if isinstance(context, str):
-            reversed_text = context[::-1]
-            tokens = context.split()
-            unique_tokens = len(set(tokens)) if tokens else 0
-            summary = "Processed textual context"
-            details = {
-                "transformation": "reverse",
-                "token_count": len(tokens),
-                "unique_tokens": unique_tokens,
-                "reversed": reversed_text,
-                "valence_delta": 0.02 if unique_tokens else 0.01,
-            }
-            return AdaptationResult(summary=summary, details=details)
+            return self._adapt_text(context)
 
         if isinstance(context, (list, tuple, set, np.ndarray)):
-            sequence = list(context)
-            reversed_sequence = list(reversed(sequence))
-            mean_value = float(np.mean(sequence)) if self._is_numeric_sequence(sequence) else None
-            summary = "Processed sequence context"
-            details = {
-                "transformation": "reverse",
-                "length": len(sequence),
-                "mean": mean_value,
-                "reversed": reversed_sequence,
-                "valence_delta": 0.015,
-            }
-            return AdaptationResult(summary=summary, details=details)
+            return self._adapt_sequence(context)
 
         if isinstance(context, dict):
-            summary = "Processed mapping context"
-            details = {
-                "keys": list(context.keys()),
-                "values": list(context.values()),
-                "valence_delta": 0.012,
-            }
-            return AdaptationResult(summary=summary, details=details)
+            return self._adapt_mapping(context)
 
-        if isinstance(context, (int, float)):
-            summary = "Processed numeric context"
-            details = {
-                "value": context,
-                "normalized": self._normalize_numeric(context),
-                "valence_delta": 0.01,
-            }
-            return AdaptationResult(summary=summary, details=details)
+        if isinstance(context, (int, float)) and not isinstance(context, bool):
+            return self._adapt_numeric(context)
 
         summary = "Processed miscellaneous context"
-        details = {"representation": repr(context), "valence_delta": 0.005}
-        return AdaptationResult(summary=summary, details=details)
+        details = {
+            "representation": repr(context),
+            "type_name": type(context).__name__,
+            "valence_delta": 0.005,
+        }
+        return AdaptationResult(
+            summary=summary,
+            details=details,
+            strategy="fallback-representation",
+            confidence=0.35,
+            signals=["unknown_type"],
+        )
+
+    def _adapt_text(self, context: str) -> AdaptationResult:
+        tokens = re.findall(r"\b[\w'-]+\b", context.lower())
+        unique_tokens = len(set(tokens))
+        token_count = len(tokens)
+        lexical_diversity = unique_tokens / token_count if token_count else 0.0
+        repeated_terms = [
+            term for term, count in Counter(tokens).most_common(5) if count > 1
+        ]
+        sentence_count = len(
+            [part for part in re.split(r"[.!?]+", context) if part.strip()]
+        )
+        avg_token_length = (
+            sum(len(token) for token in tokens) / token_count if token_count else 0.0
+        )
+        signals = ["empty_text"] if not context.strip() else ["textual_signal"]
+        if lexical_diversity >= 0.8 and token_count >= 4:
+            signals.append("high_lexical_diversity")
+        if repeated_terms:
+            signals.append("repetition_detected")
+
+        details = {
+            "transformation": "reverse_and_profile",
+            "token_count": token_count,
+            "unique_tokens": unique_tokens,
+            "lexical_diversity": round(lexical_diversity, 4),
+            "sentence_count": sentence_count,
+            "average_token_length": round(avg_token_length, 2),
+            "repeated_terms": repeated_terms,
+            "reversed": context[::-1],
+            "valence_delta": 0.02 if unique_tokens else 0.01,
+        }
+        return AdaptationResult(
+            summary="Processed textual context with lexical profiling",
+            details=details,
+            strategy="text-lexical-profiler",
+            confidence=self._confidence_from_density(token_count, unique_tokens),
+            signals=signals,
+        )
+
+    def _adapt_sequence(self, context: Iterable[Any]) -> AdaptationResult:
+        sequence = list(context)
+        numeric = self._is_numeric_sequence(sequence)
+        numeric_stats: Dict[str, Any] = {
+            "mean": None,
+            "median": None,
+            "minimum": None,
+            "maximum": None,
+            "std_dev": None,
+        }
+        if numeric and sequence:
+            values = [float(item) for item in sequence]
+            numeric_stats = {
+                "mean": float(np.mean(values)),
+                "median": float(np.median(values)),
+                "minimum": float(np.min(values)),
+                "maximum": float(np.max(values)),
+                "std_dev": float(np.std(values)),
+            }
+
+        type_mix = dict(Counter(type(item).__name__ for item in sequence))
+        details = {
+            "transformation": "reverse_and_measure",
+            "length": len(sequence),
+            "is_numeric": numeric,
+            "type_mix": type_mix,
+            "reversed": list(reversed(sequence)),
+            "valence_delta": 0.015 if sequence else 0.004,
+            **numeric_stats,
+        }
+        signals = ["sequence_signal"]
+        if numeric:
+            signals.append("numeric_sequence")
+        if len(type_mix) > 1:
+            signals.append("heterogeneous_sequence")
+
+        return AdaptationResult(
+            summary="Processed sequence context with distribution metrics",
+            details=details,
+            strategy="sequence-distribution-analyzer",
+            confidence=0.72 if sequence else 0.42,
+            signals=signals,
+        )
+
+    def _adapt_mapping(self, context: Dict[Any, Any]) -> AdaptationResult:
+        value_types = dict(Counter(type(value).__name__ for value in context.values()))
+        nested_keys = [
+            key
+            for key, value in context.items()
+            if isinstance(value, (dict, list, tuple, set))
+        ]
+        numeric_values = [
+            value
+            for value in context.values()
+            if isinstance(value, (int, float)) and not isinstance(value, bool)
+        ]
+        details = {
+            "keys": list(context.keys()),
+            "values": list(context.values()),
+            "key_count": len(context),
+            "value_types": value_types,
+            "nested_keys": nested_keys,
+            "numeric_value_count": len(numeric_values),
+            "numeric_value_mean": (
+                float(np.mean(numeric_values)) if numeric_values else None
+            ),
+            "valence_delta": 0.012 if context else 0.004,
+        }
+        signals = ["mapping_signal"]
+        if nested_keys:
+            signals.append("nested_structure")
+        if numeric_values:
+            signals.append("numeric_fields")
+
+        return AdaptationResult(
+            summary="Processed mapping context with schema profiling",
+            details=details,
+            strategy="mapping-schema-profiler",
+            confidence=0.76 if context else 0.45,
+            signals=signals,
+        )
+
+    def _adapt_numeric(self, context: float) -> AdaptationResult:
+        magnitude = abs(float(context))
+        details = {
+            "value": context,
+            "normalized": self._normalize_numeric(float(context)),
+            "magnitude": magnitude,
+            "order_of_magnitude": math.floor(math.log10(magnitude)) if magnitude else 0,
+            "polarity": (
+                "positive" if context > 0 else "negative" if context < 0 else "zero"
+            ),
+            "valence_delta": 0.01,
+        }
+        return AdaptationResult(
+            summary="Processed numeric context with magnitude analysis",
+            details=details,
+            strategy="numeric-signal-normalizer",
+            confidence=0.8,
+            signals=["numeric_signal", details["polarity"]],
+        )
 
     @staticmethod
     def _is_numeric_sequence(sequence: Iterable[Any]) -> bool:
-        return all(isinstance(item, (int, float)) for item in sequence)
+        return all(
+            isinstance(item, (int, float)) and not isinstance(item, bool)
+            for item in sequence
+        )
 
     @staticmethod
     def _normalize_numeric(value: float) -> float:
-        return 1 / (1 + np.exp(-value))
+        if value >= 0:
+            z = math.exp(-value) if value < 709 else 0.0
+            return 1 / (1 + z)
+        z = math.exp(value) if value > -709 else 0.0
+        return z / (1 + z)
+
+    @staticmethod
+    def _confidence_from_density(token_count: int, unique_tokens: int) -> float:
+        if token_count == 0:
+            return 0.4
+        density = unique_tokens / token_count
+        return min(0.95, 0.5 + (density * 0.4) + min(token_count, 20) / 200)

--- a/core.py
+++ b/core.py
@@ -7,26 +7,47 @@ else:
     from adaptation import AdaptiveLoop
     from reflection import ReflectiveProcessor
 
+
 class AdaptiveAgent:
+    """High-level facade that orchestrates observation, adaptation, and reflection."""
+
     def __init__(self):
         self.state = IntrospectiveState()
         self.adaptive_loop = AdaptiveLoop(self.state)
         self.reflective_processor = ReflectiveProcessor(self.state)
 
     def process(self, input_context):
+        """Process one input context and return a structured lifecycle report."""
+
         self.state.observe(input_context)
         adaptation = self.adaptive_loop.run()
         reflection = self.reflective_processor.reflect(adaptation)
         return {
             "processed_context": adaptation.details if adaptation else None,
             "adaptation_summary": adaptation.summary if adaptation else None,
+            "adaptation": adaptation.to_dict() if adaptation else None,
             "reflection": reflection,
-            "meta_state": self.state.report()
+            "meta_state": self.state.report(),
         }
 
     def process_batch(self, contexts):
         """Process a sequence of contexts and return all results."""
+
         return [self.process(ctx) for ctx in contexts]
+
+    def diagnose(self) -> dict:
+        """Return a compact health report for monitoring and UI integrations."""
+
+        report = self.state.report()
+        return {
+            "history_length": report["history_length"],
+            "dominant_context_type": report["dominant_context_type"],
+            "cognitive_load": report["cognitive_load"],
+            "valence_trend": report["valence_trend"],
+            "recommendation": self.reflective_processor._recommend_next_focus(
+                report, None
+            ),
+        }
 
     def reset_state(self) -> None:
         """Reset the agent to a fresh introspective state."""
@@ -41,12 +62,14 @@ class AdaptiveAgent:
     def save_state(self, filepath: str) -> None:
         """Save the agent's internal state to a file."""
         import json
-        with open(filepath, 'w') as f:
+
+        with open(filepath, "w", encoding="utf-8") as f:
             json.dump(self.state.to_dict(), f, default=str, indent=2)
 
     def load_state(self, filepath: str) -> None:
         """Load the agent's internal state from a file."""
         import json
-        with open(filepath, 'r') as f:
+
+        with open(filepath, "r", encoding="utf-8") as f:
             data = json.load(f)
             self.state.load_from_dict(data)

--- a/introspection.py
+++ b/introspection.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections import deque
+from collections import Counter, deque
 from statistics import mean
 from typing import Any, Deque, Dict, List
 
@@ -10,16 +10,13 @@ from typing import Any, Deque, Dict, List
 class IntrospectiveState:
     """Tracks the internal history and meta-context for the agent.
 
-    The original project stored only the latest context and a simple valence
-    value.  To make the agent more informative we now maintain:
-
-    - A rolling memory of recent contexts for lightweight analysis.
-    - Type statistics for quick introspective reporting.
-    - A history of valence updates so we can provide trend information.
-    - A registry of the most recent adaptations for later reflection.
+    The state keeps a compact rolling memory rather than pretending to be an
+    autonomous consciousness. It captures observable processing signals so the
+    rest of the framework can explain what it did and why.
     """
 
     HISTORY_WINDOW = 5
+    CONTEXT_TYPES = ("text", "sequence", "mapping", "numeric", "other")
 
     def __init__(self) -> None:
         self.history: List[Any] = []
@@ -27,28 +24,32 @@ class IntrospectiveState:
         self.meta_context: Dict[str, Any] = {}
         self.emotional_valence: float = 0.0
         self.valence_trace: Deque[float] = deque(maxlen=self.HISTORY_WINDOW)
-        self.context_stats: Dict[str, int] = {
-            "text": 0,
-            "sequence": 0,
-            "mapping": 0,
-            "numeric": 0,
-            "other": 0,
-        }
+        self.context_stats: Dict[str, int] = {name: 0 for name in self.CONTEXT_TYPES}
         self.adaptation_log: Deque[str] = deque(maxlen=self.HISTORY_WINDOW)
+        self.signal_trace: Deque[List[str]] = deque(maxlen=self.HISTORY_WINDOW)
+        self.transition_counts: Dict[str, int] = {}
 
     def observe(self, context: Any) -> None:
         """Store the incoming context and update summary information."""
 
+        previous_descriptor = self.meta_context.get("last_descriptor")
+        descriptor = self._describe_context(context)
         self.history.append(context)
         self.recent_contexts.append(context)
-        descriptor = self._describe_context(context)
-        self.context_stats[descriptor] += 1
+        self.context_stats[descriptor] = self.context_stats.get(descriptor, 0) + 1
+
+        if previous_descriptor:
+            transition = f"{previous_descriptor}->{descriptor}"
+            self.transition_counts[transition] = (
+                self.transition_counts.get(transition, 0) + 1
+            )
 
         self.meta_context.update(
             {
                 "last": context,
                 "last_descriptor": descriptor,
                 "last_size": self._estimate_size(context),
+                "novelty_score": self._calculate_novelty(descriptor),
             }
         )
 
@@ -63,6 +64,11 @@ class IntrospectiveState:
 
         self.adaptation_log.append(summary)
 
+    def record_signal_bundle(self, signals: List[str]) -> None:
+        """Remember the latest adaptation signals for reporting."""
+
+        self.signal_trace.append(list(signals))
+
     def report(self) -> Dict[str, Any]:
         """Produce an introspection report consumed by downstream modules."""
 
@@ -75,7 +81,14 @@ class IntrospectiveState:
             "emotional_valence": round(self.emotional_valence, 4),
             "valence_trend": round(rolling_average, 4),
             "context_stats": dict(self.context_stats),
+            "dominant_context_type": self._dominant_context_type(),
+            "novelty_score": round(self.meta_context.get("novelty_score", 0.0), 4),
+            "cognitive_load": round(self._cognitive_load(), 4),
             "recent_adaptations": list(self.adaptation_log),
+            "recent_signals": [
+                signal for bundle in self.signal_trace for signal in bundle
+            ][-10:],
+            "transition_counts": dict(self.transition_counts),
         }
 
     def summarize_recent_contexts(self) -> List[str]:
@@ -90,6 +103,7 @@ class IntrospectiveState:
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize the current state to a dictionary."""
+
         return {
             "history": self.history,
             "recent_contexts": list(self.recent_contexts),
@@ -98,10 +112,13 @@ class IntrospectiveState:
             "valence_trace": list(self.valence_trace),
             "context_stats": self.context_stats,
             "adaptation_log": list(self.adaptation_log),
+            "signal_trace": list(self.signal_trace),
+            "transition_counts": self.transition_counts,
         }
 
     def load_from_dict(self, data: Dict[str, Any]) -> None:
         """Restore the state from a dictionary."""
+
         self.history = data.get("history", [])
         self.recent_contexts = deque(
             data.get("recent_contexts", []), maxlen=self.HISTORY_WINDOW
@@ -111,13 +128,16 @@ class IntrospectiveState:
         self.valence_trace = deque(
             data.get("valence_trace", []), maxlen=self.HISTORY_WINDOW
         )
-        self.context_stats = data.get(
-            "context_stats",
-            {"text": 0, "sequence": 0, "mapping": 0, "numeric": 0, "other": 0},
-        )
+        default_stats = {name: 0 for name in self.CONTEXT_TYPES}
+        default_stats.update(data.get("context_stats", {}))
+        self.context_stats = default_stats
         self.adaptation_log = deque(
             data.get("adaptation_log", []), maxlen=self.HISTORY_WINDOW
         )
+        self.signal_trace = deque(
+            data.get("signal_trace", []), maxlen=self.HISTORY_WINDOW
+        )
+        self.transition_counts = data.get("transition_counts", {})
 
     def _describe_context(self, context: Any) -> str:
         if isinstance(context, str):
@@ -126,7 +146,7 @@ class IntrospectiveState:
             return "sequence"
         if isinstance(context, dict):
             return "mapping"
-        if isinstance(context, (int, float)):
+        if isinstance(context, (int, float)) and not isinstance(context, bool):
             return "numeric"
         return "other"
 
@@ -138,3 +158,21 @@ class IntrospectiveState:
         if isinstance(context, dict):
             return len(context.keys())
         return 1
+
+    def _calculate_novelty(self, descriptor: str) -> float:
+        total = max(len(self.history), 1)
+        descriptor_count = self.context_stats.get(descriptor, 0)
+        return 1.0 - (descriptor_count / total)
+
+    def _cognitive_load(self) -> float:
+        if not self.recent_contexts:
+            return 0.0
+        recent_sizes = [self._estimate_size(ctx) for ctx in self.recent_contexts]
+        diversity = len({self._describe_context(ctx) for ctx in self.recent_contexts})
+        return min(1.0, (mean(recent_sizes) / 100.0) + (diversity / 10.0))
+
+    def _dominant_context_type(self) -> str | None:
+        populated = {key: value for key, value in self.context_stats.items() if value}
+        if not populated:
+            return None
+        return Counter(populated).most_common(1)[0][0]

--- a/reflection.py
+++ b/reflection.py
@@ -11,6 +11,8 @@ else:
 
 
 class ReflectiveProcessor:
+    """Creates a compact explanation of the agent's latest processing cycle."""
+
     def __init__(self, state):
         self.state = state
 
@@ -18,14 +20,45 @@ class ReflectiveProcessor:
         if not self.state.history:
             return "No context to reflect on."
 
+        report = self.state.report()
         summaries = ", ".join(self.state.summarize_recent_contexts())
         valence = self.state.emotional_valence
-        trend = self.state.report()["valence_trend"]
+        trend = report["valence_trend"]
         adaptation_summary = adaptation.summary if adaptation else "No new adaptation"
+        strategy = adaptation.strategy if adaptation else "none"
+        confidence = adaptation.confidence if adaptation else 0.0
+        signals = (
+            ", ".join(adaptation.signals)
+            if adaptation and adaptation.signals
+            else "none"
+        )
+        next_focus = self._recommend_next_focus(report, adaptation)
         return (
             "Reflection: "
             f"observed {len(self.state.history)} contexts; "
             f"recent types: {summaries or 'n/a'}; "
             f"latest adaptation: {adaptation_summary}; "
-            f"valence={valence:.2f}, trend={trend:.2f}"
+            f"strategy={strategy}; confidence={confidence:.2f}; "
+            f"signals={signals}; "
+            f"novelty={report['novelty_score']:.2f}; "
+            f"cognitive_load={report['cognitive_load']:.2f}; "
+            f"valence={valence:.2f}, trend={trend:.2f}; "
+            f"next_focus={next_focus}"
         )
+
+    def _recommend_next_focus(
+        self, report: dict, adaptation: Optional[AdaptationResult]
+    ) -> str:
+        """Suggest a deterministic next focus from observable state metrics."""
+
+        if not adaptation:
+            return "collect_more_context"
+        if report["cognitive_load"] >= 0.75:
+            return "summarize_or_chunk_inputs"
+        if report["novelty_score"] >= 0.6:
+            return "compare_against_prior_contexts"
+        if adaptation.confidence < 0.5:
+            return "request_more_structured_input"
+        if "repetition_detected" in adaptation.signals:
+            return "compress_repeated_terms"
+        return "continue_monitoring_patterns"

--- a/simulation.py
+++ b/simulation.py
@@ -47,10 +47,15 @@ def summarize_results(results: List[dict]) -> dict:
         }
 
     last = results[-1]
+    meta_state = last.get("meta_state", {})
+    adaptation = last.get("adaptation") or {}
     return {
         "total_steps": len(results),
         "last_adaptation_summary": last.get("adaptation_summary"),
-        "final_history_length": last.get("meta_state", {}).get("history_length", 0),
+        "final_history_length": meta_state.get("history_length", 0),
+        "dominant_context_type": meta_state.get("dominant_context_type"),
+        "cognitive_load": meta_state.get("cognitive_load"),
+        "last_strategy": adaptation.get("strategy"),
     }
 
 
@@ -85,12 +90,16 @@ def load_inputs_from_file(filepath: str) -> List[object]:
     if isinstance(parsed, list):
         return parsed
 
-    raise ValueError("Input file must contain a JSON array or newline-delimited entries.")
+    raise ValueError(
+        "Input file must contain a JSON array or newline-delimited entries."
+    )
 
 
 def run_interactive() -> None:
     agent = AdaptiveAgent()
-    print("Interactive Mode. Type input or commands (/save <file>, /load <file>, /quit)")
+    print(
+        "Interactive Mode. Type input or commands (/save <file>, /load <file>, /quit)"
+    )
 
     while True:
         try:
@@ -132,8 +141,12 @@ def run_interactive() -> None:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Run the adaptive cognitive framework demo.")
-    parser.add_argument("--interactive", action="store_true", help="Run in interactive mode")
+    parser = argparse.ArgumentParser(
+        description="Run the adaptive cognitive framework demo."
+    )
+    parser.add_argument(
+        "--interactive", action="store_true", help="Run in interactive mode"
+    )
     parser.add_argument(
         "--input-file",
         help="Path to a file containing demo contexts (JSON array or newline-delimited entries)",
@@ -157,10 +170,10 @@ def main(argv: list[str] | None = None) -> None:
         demo_inputs = load_inputs_from_file(args.input_file)
     else:
         demo_inputs = [
-            "First context",
+            "First context with enough words for lexical analysis",
             [1, 2, 3, 4],
-            "Another experience to analyze",
-            {"signal": 42, "status": "stable"},
+            "Another experience to analyze, compare, and refine",
+            {"signal": 42, "status": "stable", "tags": ["demo", "safe"]},
             7,
         ]
     run_demo(demo_inputs, save_state=args.save_state)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -48,17 +48,22 @@ def test_agent_process_structure():
     assert set(result.keys()) == {
         "processed_context",
         "adaptation_summary",
+        "adaptation",
         "reflection",
         "meta_state",
     }
 
     assert isinstance(result["processed_context"], dict)
     assert result["adaptation_summary"]
+    assert result["adaptation"]["strategy"] == "text-lexical-profiler"
+    assert result["adaptation"]["confidence"] > 0
     assert "valence" in result["reflection"].lower()
 
     meta_state = result["meta_state"]
     assert meta_state["history_length"] == 1
     assert meta_state["recent_context_descriptor"] == "text"
+    assert meta_state["dominant_context_type"] == "text"
+    assert "cognitive_load" in meta_state
 
     # Ensure JSON serialization works for the processed context
     json.dumps(result["processed_context"], default=str)
@@ -89,3 +94,30 @@ def test_agent_batch_snapshot_and_reset():
     agent.reset_state()
     post_reset = agent.state.report()
     assert post_reset["history_length"] == 0
+
+
+def test_agent_exposes_richer_adaptation_metrics():
+    agent = AdaptiveAgent()
+
+    text_result = agent.process("alpha beta beta gamma")
+    assert text_result["processed_context"]["repeated_terms"] == ["beta"]
+    assert "repetition_detected" in text_result["adaptation"]["signals"]
+
+    sequence_result = agent.process([1, 2, 3, 4])
+    assert sequence_result["processed_context"]["is_numeric"] is True
+    assert sequence_result["processed_context"]["median"] == 2.5
+
+    mapping_result = agent.process({"a": 1, "nested": [1, 2]})
+    assert mapping_result["processed_context"]["nested_keys"] == ["nested"]
+    assert "sequence->mapping" in mapping_result["meta_state"]["transition_counts"]
+
+
+def test_agent_diagnose_returns_health_snapshot():
+    agent = AdaptiveAgent()
+    agent.process("diagnostic input")
+
+    diagnosis = agent.diagnose()
+
+    assert diagnosis["history_length"] == 1
+    assert diagnosis["dominant_context_type"] == "text"
+    assert diagnosis["recommendation"]

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -25,8 +25,8 @@ def test_load_inputs_from_json_array_file():
 def test_load_inputs_from_newline_file():
     with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".txt") as tmp:
         tmp.write('{"x": 1}\n')
-        tmp.write('plain\n')
-        tmp.write('[1,2]\n')
+        tmp.write("plain\n")
+        tmp.write("[1,2]\n")
         tmp_path = tmp.name
 
     try:
@@ -58,4 +58,7 @@ def test_summarize_results_handles_empty_and_populated_inputs():
         "total_steps": 2,
         "last_adaptation_summary": "Processed list",
         "final_history_length": 2,
+        "dominant_context_type": None,
+        "cognitive_load": None,
+        "last_strategy": None,
     }


### PR DESCRIPTION
### Motivation

- Improve the agent's adaptation pipeline to produce richer, structured outputs for downstream tooling and UIs. 
- Provide deeper per-type profiling (text, sequence, mapping, numeric) and surface introspection metrics (signals, transitions, novelty, cognitive load) so behaviour can be explained and monitored. 

### Description

- Extend `AdaptationResult` with `strategy`, `confidence`, `signals`, and `to_dict()` and replace the single `_adapt_context` implementation with type-specific helpers (`_adapt_text`, `_adapt_sequence`, `_adapt_mapping`, `_adapt_numeric`) that emit profiling metrics (lexical diversity, repeated terms, distribution stats, schema profiling, magnitude analysis). (`adaptation.py`).
- Record and expose adaptation signals from `AdaptiveLoop.run()` and return a richer adaptation payload from `AdaptiveAgent.process()` while keeping backward-compatible summary fields, and add a `diagnose()` helper for compact health snapshots. (`core.py`).
- Expand `IntrospectiveState` to track `signal_trace`, `transition_counts`, `novelty_score`, `cognitive_load`, and `dominant_context_type`, plus updated serialization/load behaviour. (`introspection.py`).
- Improve `ReflectiveProcessor` to include strategy, confidence, signals, novelty, cognitive load, and a deterministic `next_focus` recommendation in reflection strings. (`reflection.py`).
- Update the simulation utilities to surface the new metadata in summaries and example demo inputs, and document the structured result contract in `README.md`. (`simulation.py`, `README.md`).
- Update and add tests to validate the richer contract and metrics and format code with `black`. (`tests/test_agent.py`, `tests/test_simulation.py`).

### Testing

- Ran the test suite with `pytest -q`, all tests passed (`11 passed`).
- Verified code compiles with `python -m compileall -q .` which completed without errors.
- Exercised the demo runner with `python -m simulation` and inspected output for the new metrics (sample output printed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faeb31ea448327b6fa46ca4248cac0)